### PR TITLE
Tell connectors when a round starts/stops.

### DIFF
--- a/supext/connectors.py
+++ b/supext/connectors.py
@@ -29,3 +29,11 @@ class connectors():
                 module.run(result, check)
             except Exception as e:
                 self.logger.error('Cannot add entry using {0} for check {1}: {2}'.format(name, check['name'], e))
+
+    def startRound(self):
+        for name, module, in self.modules.items():
+            module.startRound()
+
+    def stopRound(self):
+        for name, module, in self.modules.items():
+            module.stopRound()

--- a/supext/modules/connectors/cachet.py
+++ b/supext/modules/connectors/cachet.py
@@ -13,6 +13,12 @@ class cachet:
             self.certificate = config['certificate']
             self.key = config['key']
 
+    def startRound(self):
+        pass
+
+    def stopRound(self):
+        pass
+
     def getHeader(self):
         return {'X-Cachet-Token': self.token}
 

--- a/supext/modules/connectors/elasticsearch.py
+++ b/supext/modules/connectors/elasticsearch.py
@@ -8,6 +8,12 @@ class elasticsearch:
         self.es = Elasticsearch(config.get('hosts', ['localhost:443']))
         self.logger = logging.getLogger('supext')
 
+    def startRound(self):
+        pass
+
+    def stopRound(self):
+        pass
+
     def run(self, result, check):
         doc = {
             'name': check['name'],


### PR DESCRIPTION
This will allow connectors to improve networking:
1/ ElasticSearch connector could use bulk queries.
2/ CachetHQ connector could regroup checks per component, and avoid multiple updates.